### PR TITLE
set params for srcset

### DIFF
--- a/filters/imgix.js
+++ b/filters/imgix.js
@@ -38,8 +38,9 @@ const imgix = domain => {
   const returnedFunction = (src, params = {}) => {
     params = {...DEFAULT_PARAMS, ...params};
 
-    // Check if image is an SVG, if it is we don't need or want to process it
-    // If we do imgix will rasterize the image, which causes issues with a number of devtools images.
+    // Check if image is an SVG or has an explicit format set already, if it is we don't need or
+    // want to process it. If we do, imgix will rasterize the image, which causes issues with a
+    // number of devtools images.
     const doNotUseParams = isSimpleImg(src, params);
 
     return client.buildURL(src, doNotUseParams ? {} : params);

--- a/filters/imgix.js
+++ b/filters/imgix.js
@@ -23,7 +23,7 @@ const DEFAULT_PARAMS = {auto: 'format'};
  * Generates src URL of image from imgix path or URL.
  *
  * @param {string} domain imgix domain
- * @return {(src: string, params?: import('types').TODOObject) => string} Video shortcode.
+ * @return {(src: string, params?: import('types').TODOObject) => string} Helper to generate URLs.
  */
 const imgix = domain => {
   const client = new ImgixClient({domain, includeLibraryParam: false});

--- a/shortcodes/Img.js
+++ b/shortcodes/Img.js
@@ -68,7 +68,7 @@ function Img(domain) {
       style,
       width,
       params,
-    } = args;
+    } = {params: {}, ...args};
     let {decoding, loading, sizes, options} = args;
 
     const checkHereIfError = `ERROR IN ${
@@ -110,7 +110,18 @@ function Img(domain) {
       loading = 'lazy';
     }
 
-    const doNotUseSrcset = isSimpleImg(src, params);
+    // Determine if this is a SVG or something that already has an explicit format set. If so, we
+    // don't try to resize or format it in any way.
+    const simpleImg = isSimpleImg(src, params);
+    const useSrcSet = !simpleImg;
+
+    // If auto isn't already set then force "auto=format". This gives us back the best format for
+    // the browser: https://docs.imgix.com/apis/rendering/auto/auto#format
+    // This is also set in the imgix source URL filter, but we have to set it here so that imgix's
+    // code for generating a srcset accepts it too.
+    if (!params.auto && !simpleImg) {
+      params.auto = 'format';
+    }
 
     // https://github.com/imgix/imgix-core-js#imgixclientbuildsrcsetpath-params-options
     options = {
@@ -142,9 +153,9 @@ function Img(domain) {
       height="${heightAsNumber}"
       ${id ? `id="${id}"` : ''}
       ${loading ? `loading="${loading}"` : ''}
-      ${doNotUseSrcset ? '' : `sizes="${sizes}"`}
+      ${useSrcSet ? `sizes="${sizes}"` : ''}
       src="${fullSrc}"
-      ${doNotUseSrcset ? '' : `srcset="${srcset}"`}
+      ${useSrcSet ? `srcset="${srcset}"` : ''}
       ${style ? `style="${style}"` : ''}
       width="${widthAsNumber}"
     />`;

--- a/shortcodes/Img.js
+++ b/shortcodes/Img.js
@@ -118,8 +118,8 @@ function Img(domain) {
     // If auto isn't already set then force "auto=format". This gives us back the best format for
     // the browser: https://docs.imgix.com/apis/rendering/auto/auto#format
     // This is also set in the imgix source URL filter, but we have to set it here so that imgix's
-    // code for generating a srcset accepts it too. (We can't pass `fullSrc` below, because then
-    // imgix's client tries to serve us a doubly-wrapped image URL.)
+    // code for generating a srcset accepts it too. (We can't pass `fullSrc` as returned by the
+    // imgix source URL below, because then imgix's srcset code tries serve a doubly-wrapped URL.)
     if (!params.auto && !simpleImg) {
       params.auto = 'format';
     }
@@ -134,9 +134,7 @@ function Img(domain) {
       widthTolerance: 0.07,
       ...options,
     };
-    // https://docs.imgix.com/apis/rendering
-    const fullSrc = imgix(domain)(src, params);
-    const srcset = client.buildSrcSet(fullSrc, params, options);
+    const srcset = client.buildSrcSet(src, params, options);
     if (sizes === undefined) {
       if (widthAsNumber >= MAX_WIDTH) {
         sizes = `(min-width: ${MAX_WIDTH}px) ${MAX_WIDTH}px, calc(100vw - 48px)`;
@@ -146,6 +144,9 @@ function Img(domain) {
     }
 
     const hasValidAlt = alt !== undefined;
+
+    // https://docs.imgix.com/apis/rendering
+    const fullSrc = imgix(domain)(src, params);
 
     let imgTag = html` <img
       ${hasValidAlt ? `alt="${safeHtml`${alt}`}"` : ''}

--- a/shortcodes/Img.js
+++ b/shortcodes/Img.js
@@ -118,7 +118,8 @@ function Img(domain) {
     // If auto isn't already set then force "auto=format". This gives us back the best format for
     // the browser: https://docs.imgix.com/apis/rendering/auto/auto#format
     // This is also set in the imgix source URL filter, but we have to set it here so that imgix's
-    // code for generating a srcset accepts it too.
+    // code for generating a srcset accepts it too. (We can't pass `fullSrc` below, because then
+    // imgix's client tries to serve us a doubly-wrapped image URL.)
     if (!params.auto && !simpleImg) {
       params.auto = 'format';
     }
@@ -135,7 +136,7 @@ function Img(domain) {
     };
     // https://docs.imgix.com/apis/rendering
     const fullSrc = imgix(domain)(src, params);
-    const srcset = client.buildSrcSet(src, params, options);
+    const srcset = client.buildSrcSet(fullSrc, params, options);
     if (sizes === undefined) {
       if (widthAsNumber >= MAX_WIDTH) {
         sizes = `(min-width: ${MAX_WIDTH}px) ${MAX_WIDTH}px, calc(100vw - 48px)`;

--- a/types/shortcodes/Img.d.ts
+++ b/types/shortcodes/Img.d.ts
@@ -61,7 +61,13 @@ export type ImgArgs = {
    * The intrinsic width of the image in pixels. Must be an integer without a unit.
    */
   width: string;
+  /**
+   * Params directly passed to the imgix API. This can be used to make specific overrides, use with caution.
+   */
   params?: TODOObject;
+  /**
+   * Options passed when generating an imgix srcset.
+   */
   options?: ImgixOptions;
 };
 


### PR DESCRIPTION
We weren't setting "auto=format" for the srcset, so LHCI barfed since it was helpfully loading the smaller sized images which were still in JPEG or whatever default format.