### PR TITLE
Node >= v14 in engines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#4F144A",
-    "titleBar.activeBackground": "#6F1C68",
-    "titleBar.activeForeground": "#FDF8FD"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdev-infra",
-  "version": "1.0.31",
+  "version": "1.0.30",
   "description": "Contains shared code for https://web.dev, https://developer.chrome.com and others.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "webdev-infra",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "description": "Contains shared code for https://web.dev, https://developer.chrome.com and others.",
   "main": "index.js",
   "engines": {
-    "node": "14.x"
+    "node": ">=14"
   },
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
This change indicates that we're fine with using node `v14` or higher (including node `v16`), and will eliminate a warning that's logged if the project depending on this is using node `v16`.

This should be a backwards-compatible change, and we continue to support node `v14`.