### PR TITLE
Update importance to fetchpriority

### DIFF
--- a/shortcodes/Img.js
+++ b/shortcodes/Img.js
@@ -70,8 +70,8 @@ function Img(domain) {
       params,
     } = {params: {}, ...args};
     let {decoding, loading, sizes, options} = args;
-    const {importance} = args;
 
+    const {fetchpriority} = args;
     const checkHereIfError = `ERROR IN ${
       // @ts-ignore: `this` has type of `any`
       this.page ? this.page.inputPath : 'UNKNOWN'
@@ -156,8 +156,8 @@ function Img(domain) {
     let imgTag = html` <img
       ${hasValidAlt ? `alt="${safeHtml`${alt}`}"` : ''}
       ${className ? `class="${className}"` : ''}
-      ${importance ? `importance="${importance}"` : ''}
       ${decoding ? `decoding="${decoding}"` : ''}
+      ${fetchpriority ? `fetchpriority="${fetchpriority}"` : ''}
       height="${heightAsNumber}"
       ${id ? `id="${id}"` : ''}
       ${loading ? `loading="${loading}"` : ''}

--- a/types/shortcodes/Img.d.ts
+++ b/types/shortcodes/Img.d.ts
@@ -31,6 +31,10 @@ export type ImgArgs = {
    */
   decoding?: 'sync' | 'async' | 'auto';
   /**
+   * Indicates the relative priority of resources to the browser.
+   */
+  fetchpriority?: 'high' | 'low' | 'auto';
+  /**
    * The intrinsic height of the image, in pixels. Must be an integer without a unit.
    */
   height: string;
@@ -38,10 +42,6 @@ export type ImgArgs = {
    * Often used with CSS to style a specific element. The value of this attribute must be unique.
    */
   id?: string;
-  /**
-   * Indicates the relative importance of resources to the browser.
-   */
-  importance?: 'high' | 'low' | 'auto';
   /**
    * Flag to wrap image in `a` tag pointing to the image. `false` by default.
    */


### PR DESCRIPTION
Updates on the work from #21 with the now stable attribute, `fetchpriority` (instead of `importance`).