### PR TITLE
Utility module to mark future posts as drafts

### DIFF
--- a/types/eleventy/collection-item.ts
+++ b/types/eleventy/collection-item.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare global {
+  export interface EleventyCollectionItemPartial {
+    date: Date;
+    data: {
+      draft: boolean;
+    };
+    url: string;
+  }
+}
+
+// empty export to keep file a module
+export {};

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,3 +1,4 @@
 module.exports = {
   ...require('./is-simple-img'),
+  ...require('./mark-future-post-as-draft'),
 };

--- a/utils/mark-future-post-as-draft.js
+++ b/utils/mark-future-post-as-draft.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A helper to mark posts whose date are in the future as drafts.
+ *
+ * This allows authors to commit posts to GitHub and have them appear "live" at
+ * a later date. It relies on the fact that our sites deploy automatically via
+ * a regular cadence.
+ *
+ * Authors should note that because the deployment window is fairly large, it's
+ * not possible to ensure a post will go live at an exact point in time; just
+ * that it should go live at some point after the next periodic deployment.
+ *
+ * @param {EleventyCollectionItemPartial} item
+ * @param {number} currentTimeInMS
+ * @return {EleventyCollectionItemPartial}
+ */
+const markFuturePostAsDraft = (item, currentTimeInMS) => {
+  if (item.date.getTime() > currentTimeInMS) {
+    console.log(
+      `${item.url} has a future publication date of ` +
+        `${item.date.toUTCString()}, and is treated as a draft.`
+    );
+    item.data.draft = true;
+  }
+  return item;
+};
+
+module.exports = {markFuturePostAsDraft};


### PR DESCRIPTION
This can then be used for https://github.com/GoogleChrome/web.dev/issues/6826 and for the corresponding functionality on d.c.c.

CC: @rachelandrew