### PR TITLE
Implement new html minify transform based on @swc/html

### DIFF
--- a/filters/minifyHtml.js
+++ b/filters/minifyHtml.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Async nunjucks filter to minify a HTML fragment
+ */
+
+const swcHtml = require('@swc/html');
+const {swcHtmlOptions} = require('../transforms/minifyHtml');
+
+async function minifyHtml(html) {
+  const result = await swcHtml.minify(Buffer.from(html), swcHtmlOptions);
+  return result.code;
+}
+
+module.exports = {minifyHtml};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
+        "@swc/html": "0.0.18",
         "browser-media-mime-type": "^1.0.0",
         "common-tags": "^1.8.0",
         "csso": "5.0.5",
@@ -780,6 +781,224 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@swc/html": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html/-/html-0.0.18.tgz",
+      "integrity": "sha512-EiA134Oa5sneQqMfsWcEcDaEVX1Grtb82S6nUqPUI/t7LQzg4lO7Wcp3Fqy2UwpVsL4otWM03gD65qEr5ZPf2A==",
+      "engines": {
+        "node": ">=14"
+      },
+      "optionalDependencies": {
+        "@swc/html-android-arm-eabi": "0.0.18",
+        "@swc/html-android-arm64": "0.0.18",
+        "@swc/html-darwin-arm64": "0.0.18",
+        "@swc/html-darwin-x64": "0.0.18",
+        "@swc/html-freebsd-x64": "0.0.18",
+        "@swc/html-linux-arm-gnueabihf": "0.0.18",
+        "@swc/html-linux-arm64-gnu": "0.0.18",
+        "@swc/html-linux-arm64-musl": "0.0.18",
+        "@swc/html-linux-x64-gnu": "0.0.18",
+        "@swc/html-linux-x64-musl": "0.0.18",
+        "@swc/html-win32-arm64-msvc": "0.0.18",
+        "@swc/html-win32-ia32-msvc": "0.0.18",
+        "@swc/html-win32-x64-msvc": "0.0.18"
+      }
+    },
+    "node_modules/@swc/html-android-arm-eabi": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-android-arm-eabi/-/html-android-arm-eabi-0.0.18.tgz",
+      "integrity": "sha512-2/76+aJnzgoE2U+gaKfj/2Qbkx7OHTJyfP7qFdfvMb6zQsc6gQMqp3KDPXK3wmt4aPTifryl/QzIBAYFVyGXvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-android-arm64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-android-arm64/-/html-android-arm64-0.0.18.tgz",
+      "integrity": "sha512-7bVCnuJvqPUghLaBgWuZUG4fayR8UZCcnBb9PAktL2a/r97KlKgHOwN7Z9T5d7PdXu3af3x3jN7c2gSKe1Zpmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-darwin-arm64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-0.0.18.tgz",
+      "integrity": "sha512-fBHsO5+qfxvKulFuEIpoo32UOPN1N3478lRfcimENp9Cu0wWe4coLZVGKMaDdRJpMR0U8DEzeybrocpns89R2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-darwin-x64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-0.0.18.tgz",
+      "integrity": "sha512-5hFbhf1ghUW1uZq2yHMp9GewmSf/1IAH5x7MlC+LhuBjEFDlTyY9ax2fK5YVwZwbMJh4LfgtN7ydFVUfNvHB1g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-freebsd-x64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-freebsd-x64/-/html-freebsd-x64-0.0.18.tgz",
+      "integrity": "sha512-AHBEiIqyy4FD2yUxtfPG5yopXh7tDCKV1OSXavdaAqikx8EwG3ok85WsgbPPBAfZMttHkp/mvYmxE2MZE1dhDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-arm-gnueabihf": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-0.0.18.tgz",
+      "integrity": "sha512-en0EokMYRY6kB/BqGDwGY56xe7bPbN+I6VhHho1FTy0UPuh8FhYDpev/J7qgmwVlh6Ch27SDzGF8ly0tXbjQWA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-arm64-gnu": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-0.0.18.tgz",
+      "integrity": "sha512-gXsdpv6RVEhZYWj4CV4t9D+DWQ4iPx1fFt2ICxtvbo6dkuwNOszr/CoF+K+YwoE2DGUInmD8o4VT915n92NABQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-arm64-musl": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-0.0.18.tgz",
+      "integrity": "sha512-im/vFj2OOG+yqNfn4AMxOolo3b9L3QfJY0sJ9BOFqXDGzQjj6DYfNV03HpRHtP8+LKlDAcbmaH9K84PN1U3xZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-x64-gnu": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-0.0.18.tgz",
+      "integrity": "sha512-OCpMpFmeJTWFaFo6BkcTfHU5kx1AIU/Ad9g3LpzFyr5a/oBb1UCUVuV2Y6kUOkj93JmepsZnRkb9cr43cR6Hrg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-linux-x64-musl": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-0.0.18.tgz",
+      "integrity": "sha512-D0aiWk6yXQSk05ZH2gKrclT5VA5iAQfKaujmzQr+MZ+iSdMpCp+BHNi4xPuOCEnAbQ38qv6PfSY+zuszjC/utA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-win32-arm64-msvc": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-0.0.18.tgz",
+      "integrity": "sha512-8dE0Q8g5pIP+u8aFZmKZzud7/JH1evcRLLEktdICDj5cO67eC8yTfxpQ8NwyAmf6VFVaOaCELSjX2RaYYsEViw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-win32-ia32-msvc": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-0.0.18.tgz",
+      "integrity": "sha512-HxuBUmDc7xuTn7JD+VU7LfxP5X1XzgBbskomb8/9yoZglqpPNT200DIf8/JbP9Kv692VP5ACNIpJ6jpCfbF1kA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/html-win32-x64-msvc": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-0.0.18.tgz",
+      "integrity": "sha512-pZ93lqOtFdalit3EGinbbmFdT+sACo+QG6uiVsAU6tynjkJjeJxKq3TC6D3m8QQDRnEe8BViTwoEAyZ00ouuhA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -8061,6 +8280,104 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
+    },
+    "@swc/html": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html/-/html-0.0.18.tgz",
+      "integrity": "sha512-EiA134Oa5sneQqMfsWcEcDaEVX1Grtb82S6nUqPUI/t7LQzg4lO7Wcp3Fqy2UwpVsL4otWM03gD65qEr5ZPf2A==",
+      "requires": {
+        "@swc/html-android-arm-eabi": "0.0.18",
+        "@swc/html-android-arm64": "0.0.18",
+        "@swc/html-darwin-arm64": "0.0.18",
+        "@swc/html-darwin-x64": "0.0.18",
+        "@swc/html-freebsd-x64": "0.0.18",
+        "@swc/html-linux-arm-gnueabihf": "0.0.18",
+        "@swc/html-linux-arm64-gnu": "0.0.18",
+        "@swc/html-linux-arm64-musl": "0.0.18",
+        "@swc/html-linux-x64-gnu": "0.0.18",
+        "@swc/html-linux-x64-musl": "0.0.18",
+        "@swc/html-win32-arm64-msvc": "0.0.18",
+        "@swc/html-win32-ia32-msvc": "0.0.18",
+        "@swc/html-win32-x64-msvc": "0.0.18"
+      }
+    },
+    "@swc/html-android-arm-eabi": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-android-arm-eabi/-/html-android-arm-eabi-0.0.18.tgz",
+      "integrity": "sha512-2/76+aJnzgoE2U+gaKfj/2Qbkx7OHTJyfP7qFdfvMb6zQsc6gQMqp3KDPXK3wmt4aPTifryl/QzIBAYFVyGXvQ==",
+      "optional": true
+    },
+    "@swc/html-android-arm64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-android-arm64/-/html-android-arm64-0.0.18.tgz",
+      "integrity": "sha512-7bVCnuJvqPUghLaBgWuZUG4fayR8UZCcnBb9PAktL2a/r97KlKgHOwN7Z9T5d7PdXu3af3x3jN7c2gSKe1Zpmw==",
+      "optional": true
+    },
+    "@swc/html-darwin-arm64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-0.0.18.tgz",
+      "integrity": "sha512-fBHsO5+qfxvKulFuEIpoo32UOPN1N3478lRfcimENp9Cu0wWe4coLZVGKMaDdRJpMR0U8DEzeybrocpns89R2Q==",
+      "optional": true
+    },
+    "@swc/html-darwin-x64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-0.0.18.tgz",
+      "integrity": "sha512-5hFbhf1ghUW1uZq2yHMp9GewmSf/1IAH5x7MlC+LhuBjEFDlTyY9ax2fK5YVwZwbMJh4LfgtN7ydFVUfNvHB1g==",
+      "optional": true
+    },
+    "@swc/html-freebsd-x64": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-freebsd-x64/-/html-freebsd-x64-0.0.18.tgz",
+      "integrity": "sha512-AHBEiIqyy4FD2yUxtfPG5yopXh7tDCKV1OSXavdaAqikx8EwG3ok85WsgbPPBAfZMttHkp/mvYmxE2MZE1dhDQ==",
+      "optional": true
+    },
+    "@swc/html-linux-arm-gnueabihf": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-0.0.18.tgz",
+      "integrity": "sha512-en0EokMYRY6kB/BqGDwGY56xe7bPbN+I6VhHho1FTy0UPuh8FhYDpev/J7qgmwVlh6Ch27SDzGF8ly0tXbjQWA==",
+      "optional": true
+    },
+    "@swc/html-linux-arm64-gnu": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-0.0.18.tgz",
+      "integrity": "sha512-gXsdpv6RVEhZYWj4CV4t9D+DWQ4iPx1fFt2ICxtvbo6dkuwNOszr/CoF+K+YwoE2DGUInmD8o4VT915n92NABQ==",
+      "optional": true
+    },
+    "@swc/html-linux-arm64-musl": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-0.0.18.tgz",
+      "integrity": "sha512-im/vFj2OOG+yqNfn4AMxOolo3b9L3QfJY0sJ9BOFqXDGzQjj6DYfNV03HpRHtP8+LKlDAcbmaH9K84PN1U3xZg==",
+      "optional": true
+    },
+    "@swc/html-linux-x64-gnu": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-0.0.18.tgz",
+      "integrity": "sha512-OCpMpFmeJTWFaFo6BkcTfHU5kx1AIU/Ad9g3LpzFyr5a/oBb1UCUVuV2Y6kUOkj93JmepsZnRkb9cr43cR6Hrg==",
+      "optional": true
+    },
+    "@swc/html-linux-x64-musl": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-0.0.18.tgz",
+      "integrity": "sha512-D0aiWk6yXQSk05ZH2gKrclT5VA5iAQfKaujmzQr+MZ+iSdMpCp+BHNi4xPuOCEnAbQ38qv6PfSY+zuszjC/utA==",
+      "optional": true
+    },
+    "@swc/html-win32-arm64-msvc": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-0.0.18.tgz",
+      "integrity": "sha512-8dE0Q8g5pIP+u8aFZmKZzud7/JH1evcRLLEktdICDj5cO67eC8yTfxpQ8NwyAmf6VFVaOaCELSjX2RaYYsEViw==",
+      "optional": true
+    },
+    "@swc/html-win32-ia32-msvc": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-0.0.18.tgz",
+      "integrity": "sha512-HxuBUmDc7xuTn7JD+VU7LfxP5X1XzgBbskomb8/9yoZglqpPNT200DIf8/JbP9Kv692VP5ACNIpJ6jpCfbF1kA==",
+      "optional": true
+    },
+    "@swc/html-win32-x64-msvc": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-0.0.18.tgz",
+      "integrity": "sha512-pZ93lqOtFdalit3EGinbbmFdT+sACo+QG6uiVsAU6tynjkJjeJxKq3TC6D3m8QQDRnEe8BViTwoEAyZ00ouuhA==",
+      "optional": true
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@imgix/js-core": "^3.1.3",
     "@justinribeiro/lite-youtube": "^0.9.1",
+    "@swc/html": "0.0.18",
     "browser-media-mime-type": "^1.0.0",
     "common-tags": "^1.8.0",
     "csso": "5.0.5",

--- a/tests/transforms/css/css.test.js
+++ b/tests/transforms/css/css.test.js
@@ -19,7 +19,7 @@ const fs = require('fs');
 const path = require('path');
 
 const {pagesInlineCss} = require('../../../shortcodes/InlineCss');
-const {CssTransform} = require('../../../transforms/css');
+const {CssTransform} = require('../../../transforms/inlineCss');
 
 const html = fs.readFileSync(path.join(__dirname, 'index.html'), {
   encoding: 'utf8',

--- a/tests/transforms/css/css.test.js
+++ b/tests/transforms/css/css.test.js
@@ -26,7 +26,7 @@ const html = fs.readFileSync(path.join(__dirname, 'index.html'), {
 });
 
 test.beforeEach(t => {
-  const transform = new CssTransform().configure({
+  const transform = new InlineCssTransform().configure({
     cssBasePath: path.join(__dirname),
     jsPaths: [path.join(__dirname, 'bundle.*.js')],
     insert: (content, result) => {

--- a/tests/transforms/css/css.test.js
+++ b/tests/transforms/css/css.test.js
@@ -19,7 +19,7 @@ const fs = require('fs');
 const path = require('path');
 
 const {pagesInlineCss} = require('../../../shortcodes/InlineCss');
-const {CssTransform} = require('../../../transforms/inlineCss');
+const {InlineCssTransform} = require('../../../transforms/inlineCss');
 
 const html = fs.readFileSync(path.join(__dirname, 'index.html'), {
   encoding: 'utf8',

--- a/transforms/inlineCss.js
+++ b/transforms/inlineCss.js
@@ -45,7 +45,7 @@ class InlineCssTransform {
    *   cssBasePath: string,
    *   jsPaths: string[],
    *   insert: function,
-   *   force: boolean,
+   *   force?: boolean,
    * }} config
    * @returns
    */

--- a/transforms/inlineCss.js
+++ b/transforms/inlineCss.js
@@ -33,6 +33,7 @@ const isTransformable = require('./utils/isTransformable');
 class InlineCssTransform {
   constructor() {
     this.config = {};
+    this.force = false;
     this.cssBasePath = '';
     this.css = new Map();
     this.js = '';
@@ -44,11 +45,13 @@ class InlineCssTransform {
    *   cssBasePath: string,
    *   jsPaths: string[],
    *   insert: function,
+   *   force: boolean,
    * }} config
    * @returns
    */
   configure(config) {
     this.config = config || {};
+    this.force = config.force === undefined ? false : config.force;
     // Initing is off-loaded as configuring eleventy is not allowed
     // to be async, though bootstrapping this transform involves
     // some async work (reading files, minifying CSS, ...)
@@ -147,7 +150,7 @@ class InlineCssTransform {
   async transform(output, outputPath) {
     await this.ready;
 
-    if (!isTransformable(output, outputPath)) {
+    if (!this.force && !isTransformable(output, outputPath)) {
       return output;
     }
 

--- a/transforms/inlineCss.js
+++ b/transforms/inlineCss.js
@@ -28,8 +28,9 @@ const PurgeCSS = require('purgecss').PurgeCSS;
 const csso = require('csso');
 
 const {pagesInlineCss} = require('../shortcodes/InlineCss');
+const isTransformable = require('./utils/isTransformable');
 
-class CssTransform {
+class InlineCssTransform {
   constructor() {
     this.config = {};
     this.cssBasePath = '';
@@ -72,7 +73,11 @@ class CssTransform {
   async _getCss(outputPath) {
     const cssPaths = pagesInlineCss.get(outputPath);
     if (!cssPaths) {
-      console.warn('[CSS Transformer]', outputPath, 'does not use any CSS?');
+      console.warn(
+        '[InlineCssTransformer]',
+        outputPath,
+        'does not use any CSS?'
+      );
       return '';
     }
 
@@ -111,7 +116,7 @@ class CssTransform {
 
     if (!paths.length) {
       throw new Error(
-        'The glob you passed to CssTransformer to scan for JavaScript files did not match any files.'
+        'The glob you passed to InlineCssTransformer to scan for JavaScript files did not match any files.'
       );
     }
 
@@ -128,7 +133,7 @@ class CssTransform {
 
     if (!this.js.length) {
       throw new Error(
-        'The JavaScript passed to CssTransformer is empty. Has it been built?'
+        'The JavaScript passed to InlineCssTransformer is empty. Has it been built?'
       );
     }
   }
@@ -142,17 +147,7 @@ class CssTransform {
   async transform(output, outputPath) {
     await this.ready;
 
-    // For dynamic content (e.g. rendered via Eleventy Serverless),
-    // and content that is not written (permalink: false)
-    // outputPath is false. Also we want to skip files like XML,
-    // JSON and others that might also be emitted by 11ty
-    if (!outputPath || !outputPath.endsWith('.html')) {
-      return output;
-    }
-
-    // Empty pages or pages that use different styles than the
-    // base CSS should also be skipped
-    if (!output) {
+    if (!isTransformable(output, outputPath)) {
       return output;
     }
 
@@ -184,4 +179,4 @@ class CssTransform {
   }
 }
 
-module.exports = {CssTransform};
+module.exports = {InlineCssTransform};

--- a/transforms/minifyHtml.js
+++ b/transforms/minifyHtml.js
@@ -26,17 +26,21 @@ const isTransformable = require('./utils/isTransformable');
 class MinifyHtmlTransform {
   constructor() {
     this.config = {};
+    this.force = false;
   }
 
   /**
    *
    * @param {{
    *   swcOptions: import("@swc/html").Options,
+   *   force: boolean,
    * }} config
    * @returns
    */
   configure(config) {
     this.config = config || {};
+    this.force = config.force === undefined ? false : config.force;
+
     return this.transform.bind(this);
   }
 
@@ -47,7 +51,7 @@ class MinifyHtmlTransform {
    * @returns
    */
   async transform(output, outputPath) {
-    if (!isTransformable(output, outputPath)) {
+    if (!this.force && !isTransformable(output, outputPath)) {
       return output;
     }
 

--- a/transforms/minifyHtml.js
+++ b/transforms/minifyHtml.js
@@ -76,10 +76,7 @@ class MinifyHtmlTransform {
     }
 
     try {
-      const result = await swcHtml.minify(
-        Buffer.from(output),
-        swcHtmlOptions
-      );
+      const result = await swcHtml.minify(Buffer.from(output), swcHtmlOptions);
       return result.code;
     } catch (err) {
       console.error(

--- a/transforms/minifyHtml.js
+++ b/transforms/minifyHtml.js
@@ -19,9 +19,28 @@
  * from templates by 11ty
  */
 
-const swcMinifier = require('@swc/html');
+const swcHtml = require('@swc/html');
 
 const isTransformable = require('./utils/isTransformable');
+
+/**
+ * @type {import("@swc/html").Options}
+ */
+const swcHtmlOptions = {
+  collapseWhitespaces: 'smart',
+  removeEmptyMetadataElements: true,
+  removeComments: true,
+  preserveComments: [],
+  removeEmptyAttributes: true,
+  removeRedundantAttributes: true,
+  collapseBooleanAttributes: true,
+  normalizeAttributes: true,
+  minifyJs: true,
+  minifyCss: true,
+  sortAttributes: true,
+  tagOmission: false,
+  selfClosingVoidElements: true,
+};
 
 class MinifyHtmlTransform {
   constructor() {
@@ -32,13 +51,14 @@ class MinifyHtmlTransform {
   /**
    *
    * @param {{
-   *   swcOptions: import("@swc/html").Options,
+   *   swcHtmlOptions: import("@swc/html").Options,
    *   force?: boolean,
    * }} config
    * @returns
    */
   configure(config) {
     this.config = config || {};
+    this.swcHtmlOptions = swcHtmlOptions || this.config.swcHtmlOptions;
     this.force = config.force === undefined ? false : config.force;
 
     return this.transform.bind(this);
@@ -56,21 +76,10 @@ class MinifyHtmlTransform {
     }
 
     try {
-      const result = await swcMinifier.minify(Buffer.from(output), {
-        collapseWhitespaces: 'smart',
-        removeEmptyMetadataElements: true,
-        removeComments: true,
-        preserveComments: [],
-        removeEmptyAttributes: true,
-        removeRedundantAttributes: true,
-        collapseBooleanAttributes: true,
-        normalizeAttributes: true,
-        minifyJs: true,
-        minifyCss: true,
-        sortAttributes: true,
-        tagOmission: false,
-        selfClosingVoidElements: true,
-      });
+      const result = await swcHtml.minify(
+        Buffer.from(output),
+        swcHtmlOptions
+      );
       return result.code;
     } catch (err) {
       console.error(
@@ -84,4 +93,4 @@ class MinifyHtmlTransform {
   }
 }
 
-module.exports = {MinifyHtmlTransform};
+module.exports = {swcHtmlOptions, MinifyHtmlTransform};

--- a/transforms/minifyHtml.js
+++ b/transforms/minifyHtml.js
@@ -33,7 +33,7 @@ class MinifyHtmlTransform {
    *
    * @param {{
    *   swcOptions: import("@swc/html").Options,
-   *   force: boolean,
+   *   force?: boolean,
    * }} config
    * @returns
    */

--- a/transforms/minifyHtml.js
+++ b/transforms/minifyHtml.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Transformer to minify HTML generated
+ * from templates by 11ty
+ */
+
+const swcMinifier = require('@swc/html');
+
+const isTransformable = require('./utils/isTransformable');
+
+class MinifyHtmlTransform {
+  constructor() {
+    this.config = {};
+  }
+
+  /**
+   *
+   * @param {{
+   *   swcOptions: import("@swc/html").Options,
+   * }} config
+   * @returns
+   */
+  configure(config) {
+    this.config = config || {};
+    return this.transform.bind(this);
+  }
+
+  /**
+   *
+   * @param {string} output
+   * @param {string} outputPath
+   * @returns
+   */
+  async transform(output, outputPath) {
+    if (!isTransformable(output, outputPath)) {
+      return output;
+    }
+
+    try {
+      const result = await swcMinifier.minify(Buffer.from(output), {
+        collapseWhitespaces: 'smart',
+        removeEmptyMetadataElements: true,
+        removeComments: true,
+        preserveComments: [],
+        removeEmptyAttributes: true,
+        removeRedundantAttributes: true,
+        collapseBooleanAttributes: true,
+        normalizeAttributes: true,
+        minifyJs: true,
+        minifyCss: true,
+        sortAttributes: true,
+        tagOmission: false,
+        selfClosingVoidElements: true,
+      });
+      return result.code;
+    } catch (err) {
+      console.error(
+        '[MinifyHtmlTransform]',
+        outputPath,
+        'could not be minified'
+      );
+    }
+
+    return output;
+  }
+}
+
+module.exports = {MinifyHtmlTransform};

--- a/transforms/utils/isTransformable.js
+++ b/transforms/utils/isTransformable.js
@@ -16,23 +16,18 @@
 
 /**
  * Checks if the transformed page has indeed output and an outputPath
- * that ends in HTML. Pages that are actually not emitted have outputPath
- * false and hence do not need to be transformed. outputPath is also false
+ * that ends in HTML. Pages that are actually not emitted (because they
+ * have set permalink: false for example) have an undefined outputPath
+ * and hence do not need to be transformed.
  * for
  * @param {string} output
  * @param {string} outputPath
  */
 module.exports = function isTransformable(output, outputPath) {
-  // For dynamic content (e.g. rendered via Eleventy Serverless),
-  // and content that is not written (permalink: false)
-  // outputPath is false. Also we want to skip files like XML,
-  // JSON and others that might also be emitted by 11ty
   if (!outputPath || !outputPath.endsWith('.html')) {
     return false;
   }
 
-  // Empty pages or pages that use different styles than the
-  // base CSS should also be skipped
   if (!output) {
     return false;
   }

--- a/transforms/utils/isTransformable.js
+++ b/transforms/utils/isTransformable.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Checks if the transformed page has indeed output and an outputPath
+ * that ends in HTML. Pages that are actually not emitted have outputPath
+ * false and hence do not need to be transformed. outputPath is also false
+ * for
+ * @param {string} output
+ * @param {string} outputPath
+ */
+module.exports = function isTransformable(output, outputPath) {
+  // For dynamic content (e.g. rendered via Eleventy Serverless),
+  // and content that is not written (permalink: false)
+  // outputPath is false. Also we want to skip files like XML,
+  // JSON and others that might also be emitted by 11ty
+  if (!outputPath || !outputPath.endsWith('.html')) {
+    return false;
+  }
+
+  // Empty pages or pages that use different styles than the
+  // base CSS should also be skipped
+  if (!output) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
This adds a new unified transformer to minify HTML, based on @swc/html, which is implemented in Rust. The configuration produces output that is very similar to what html-minifier (which is currently used) produces. Potentially breaking minifications (like removing `all` whitespace instead of `smart` or omitting tags) are disabled.

Using this on DCC brings down build times by around 45%. Tested on an M1 Pro, we are coming from 330.24s (80.1ms/page) down to 180.36s (43.7ms/page).