### PR TITLE
feat: make maximum threads for parallel work configurable

### DIFF
--- a/transforms/inlineCss.js
+++ b/transforms/inlineCss.js
@@ -28,6 +28,7 @@ const Piscina = require('piscina');
 const {pagesInlineCss} = require('../shortcodes/InlineCss');
 const isTransformable = require('./utils/isTransformable');
 const purgeCss = require('./utils/purgeCss');
+const getMaxThreads = require('./utils/getMaxThreads');
 
 class InlineCssTransform {
   constructor() {
@@ -55,6 +56,7 @@ class InlineCssTransform {
     this.force = config.force === undefined ? false : config.force;
     if (config.pool) {
       this.pool = new Piscina({
+        maxThreads: getMaxThreads(),
         filename: path.join(__dirname, 'utils/purgeCss.js'),
       });
     }

--- a/transforms/utils/getMaxThreads.js
+++ b/transforms/utils/getMaxThreads.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const os = require('os');
+
+const maxThreadsFraction = parseFloat(
+  process.env.WEBDEV_INFRA_MAX_THREADS || '0.9'
+);
+
+/**
+ * Determines the number of available CPUs and uses a configured
+ * fraction (defaulting to 90%) to calculate the maximum number
+ * of threads that should be used for parallel work
+ * @returns The number of usable threads as an integer
+ */
+module.exports = function getMaxThreads() {
+  return Math.round(maxThreadsFraction * os.cpus().length);
+};


### PR DESCRIPTION
Some build environments (Netlify 👀) have resource limits that are exceeded if we use all available cores for parallel work. This small util sets a default (90% of all cores) with some room for wiggle but would also allow power users to use full force for builds.