### PR TITLE
Intial workspace (Youtube shortcode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ git push && git push --tags
 ```
 
 This will cause CI to release a new version to npm.
+
+## Workspaces
+This repository makes use of NPM workspaces to leverage publishing multiple packages from one monorepo under the vendor namespace @webdev-infra (https://docs.npmjs.com/cli/v7/using-npm/workspaces)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "webdev-infra",
       "version": "1.0.41",
       "license": "Apache-2.0",
+      "workspaces": [
+        "shortcodes/youtube"
+      ],
       "dependencies": {
         "@imgix/js-core": "^3.1.3",
         "@justinribeiro/lite-youtube": "^0.9.1",
@@ -1260,6 +1263,10 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@webdev-infra/youtube": {
+      "resolved": "shortcodes/youtube",
+      "link": true
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -7811,6 +7818,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "shortcodes/youtube": {
+      "name": "@webdev-infra/youtube",
+      "version": "1.0.41",
+      "license": "ISC",
+      "dependencies": {
+        "common-tags": "^1.8.0"
+      }
     }
   },
   "dependencies": {
@@ -8629,6 +8644,12 @@
           "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
           "dev": true
         }
+      }
+    },
+    "@webdev-infra/youtube": {
+      "version": "file:shortcodes/youtube",
+      "requires": {
+        "common-tags": "^1.8.0"
       }
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
     "gts": "^3.1.0",
     "npm-run-all": "^4.1.5",
     "typescript": "^4.0.3"
-  }
+  },
+  "workspaces": [
+    "shortcodes/youtube"
+  ]
 }

--- a/shortcodes/youtube/YouTube.js
+++ b/shortcodes/youtube/YouTube.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {html} = require('common-tags');
+
+/**
+ * A YouTube video embed.
+ *
+ * Be sure to import custom element from `web-components/YouTube.js`
+ * in order to use this shortcode.
+ *
+ * @param {string|import('types').YouTubeArgs} args
+ * @return {string}
+ */
+const YouTube = args => {
+  if (typeof args === 'string') {
+    args = {id: args};
+  }
+
+  const {id, startTime} = args;
+
+  if (!id) {
+    throw new Error('No `id` provided to YouTube shortcode.');
+  }
+
+  return html`
+    <div class="youtube">
+      <lite-youtube
+        videoid="${id}"
+        ${startTime ? `videoStartAt="${startTime}"` : ''}
+      >
+      </lite-youtube>
+    </div>
+  `.replace(/\n/g, '');
+};
+
+module.exports = {YouTube};

--- a/shortcodes/youtube/package.json
+++ b/shortcodes/youtube/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@webdev-infra/shortcode-youtube",
+  "version": "1.0.41",
+  "description": "",
+  "main": "YouTube.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GoogleChrome/webdev-infra.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/GoogleChrome/webdev-infra/issues"
+  },
+  "homepage": "https://github.com/GoogleChrome/webdev-infra#readme",
+  "dependencies": {
+    "common-tags": "^1.8.0"
+  },
+  "keywords": [
+    "eleventy",
+    "shortcode",
+    "youtube"
+  ]
+}


### PR DESCRIPTION
This resolves #4439 on developer.chrome.com

It adds the ability to publish multiple packages while still retaining a monorepo structure, with one of the abstracted packages being the youtube shortcode as an initial proof of concept.

If and when this gets merged the next steps would be to publish to a package registry, either github or NPM. The current main package for this repository is public so either is ok, but github does have the extra advantage of a specialised tab on the repo that can consolidate all packages this repository produces, making for a good general quick reference resource that auto updates itself. The prerequisite for this is having an organisation account on github (already done), and setting a custom registry URL.

Once the youtube shortcode package is published the package can then be installed on both DCC and web dev, and depending on the success of that slowly introduce more packages into the monorepo vendor namespace