### PR TITLE
Implement Assert shortcode

### DIFF
--- a/shortcodes/Assert.js
+++ b/shortcodes/Assert.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Can be used like {% assert val 'Val is not truthy!' %} to be
+ * able to throw more specific error messages, for example if
+ * data is missing in templates
+ * @param {{
+ *  value: any,
+ *  error: string,
+ * }} param0
+ * @returns
+ */
+function Assert({value, error}) {
+  if (!value) {
+    throw new Error(error);
+  } else {
+    return '';
+  }
+}
+
+module.exports = {Assert};

--- a/tests/shortcodes/Assert.test.js
+++ b/tests/shortcodes/Assert.test.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const test = require('ava').default;
+
+const {Assert} = require('../../shortcodes/Assert');
+
+test('runs silently if value is true', async t => {
+  t.assert(Assert({value: true, error: 'error'}) === '');
+});
+
+test('throws if value is false', async t => {
+  t.throws(() => {
+    Assert({value: false, error: 'error'});
+  });
+});
+
+test('throws with specified message if value is false', async t => {
+  t.throws(
+    () => {
+      Assert({value: false, error: 'custom error'});
+    },
+    {message: 'custom error'}
+  );
+});


### PR DESCRIPTION
This adds a simple new shortcode that can be used to run assertions in templates. This can be useful to test data integrity at template level and provide more helpful error messages. For example, using an author on d.c.c that has no proper data in the i18n files, fails with

```
[11ty] 2. (./site/_includes/layouts/home.njk) [Line 23, Column 27]
[11ty]   EleventyShortcodeError: Error with Nunjucks shortcode `Img` (via Template render error)
[11ty] 3. ERROR IN ./site/en/index.md, IMG image/tcFciHGuF3MxnTr1y5ue01OGLBn2/PFaMfvDZoPorronbpdU8.svg: alt text must be a string, received a object (via Template render error)
[11ty]
```

By using this shortcode like this:

```jinja2
{% Assert value=authorTitle | i18n(locale) | dump != '{}', error='No i18n data for author ' + authorId %}
```

The user knows what's wrong without consulting infra. Part of https://github.com/GoogleChrome/developer.chrome.com/issues/4327.