### PR TITLE
feat: unified YouTube shortcode between web.dev and DCC version

### DIFF
--- a/shortcodes/YouTube.js
+++ b/shortcodes/YouTube.js
@@ -23,11 +23,12 @@ const {html} = require('common-tags');
  * in order to use this shortcode.
  *
  * @param {string|import('types').YouTubeArgs} args
+ * @param {string|number} [option]
  * @return {string}
  */
-const YouTube = args => {
+function YouTube(args, option) {
   if (typeof args === 'string') {
-    args = {id: args};
+    args = {id: args, startTime: option};
   }
 
   const {id, startTime} = args;
@@ -45,6 +46,6 @@ const YouTube = args => {
       </lite-youtube>
     </div>
   `.replace(/\n/g, '');
-};
+}
 
 module.exports = {YouTube};

--- a/shortcodes/YouTube.js
+++ b/shortcodes/YouTube.js
@@ -19,19 +19,25 @@ const {html} = require('common-tags');
 /**
  * A YouTube video embed.
  *
+ * The method allows a list of arguments or an object with named props.
+ * This makes it possible to declare the video id and the start time as
+ * named or anonymous parameters while using the shortcode.
+ *
  * Be sure to import custom element from `web-components/YouTube.js`
  * in order to use this shortcode.
  *
- * @param {string|import('types').YouTubeArgs} args
- * @param {string|number} [option]
+ * @param {...(string|import('types').YouTubeArgs)} options
  * @return {string}
  */
-function YouTube(args, option) {
-  if (typeof args === 'string') {
-    args = {id: args, startTime: option};
-  }
+function YouTube(...options) {
+  let id, startTime;
 
-  const {id, startTime} = args;
+  if (typeof options[0] === 'string') {
+    [id, startTime] = options;
+  } else {
+    id = options[0].id;
+    startTime = options[0].startTime;
+  }
 
   if (!id) {
     throw new Error('No `id` provided to YouTube shortcode.');


### PR DESCRIPTION
Solves issue #50 

- added support for startTime having anon params

Test log: 

- tested the shortcode locally
- tested it with different combinations of parameters (anonymous, named, optional)
- tested it on different pages to make sure the shortcodes already in use kept working