### PR TITLE
54 Better format browserCompat Widget for RSS readers

### DIFF
--- a/shortcodes/BrowserCompat/styles.scss
+++ b/shortcodes/BrowserCompat/styles.scss
@@ -18,9 +18,15 @@
   }
 
   &__items {
-    align-items: center;
     display: flex;
     margin: 1rem 1rem 1rem 0;
+    list-style: none;
+  }
+
+  &__item {
+    align-items: center;
+    display: flex;
+    justify-content: center;
   }
 
   /** The data-urls for the background-images are derived from the SVGs in the

--- a/shortcodes/BrowserCompat/template.njk
+++ b/shortcodes/BrowserCompat/template.njk
@@ -1,17 +1,19 @@
 <div class="wdi-browser-compat">
   <span class="wdi-browser-compat__label">{{- browserCompat.supportLabel -}}</span>
-  <span class="wdi-browser-compat__items">
+  <ul class="wdi-browser-compat__items">
     {% if browserCompat.browsers and browserCompat.browsers.length -%}
     {% for browser in browserCompat.browsers -%}
+    <li class="wdi-browser-compat__item">
     <span class="wdi-browser-compat__icon" data-browser="{{ browser.name }}">
       <span class="visually-hidden">{{ browser.ariaLabel }}</span>
     </span>
     <span class="wdi-browser-compat__version" data-compat="{{ browser.supportInfo.compatProperty }}">
       {{- browser.supportIcon -}}
     </span>
+    </li>
     {%- endfor %}
     {%- endif %}
-  </span>
+  </ul>
   {% if browserCompat.source -%}
   <a class="wdi-browser-compat__link" href="{{ browserCompat.source }}#browser_compatibility" target="_blank">
     {{- browserCompat.sourceLabel -}}


### PR DESCRIPTION
Fixes #54

- Changed the BrowserCompat widget HTML structure to display its content better for RSS readers
- Used an unordered list and styled it to look like the original component (followed the conversation on Web.dev [PR #7313](https://github.com/GoogleChrome/web.dev/pull/7313))

Tests:

- used the page mentioned in the original issue (https://web.dev/web-platform-01-2022) locally
- displayed the widget with styling
- displayed the widget without any styling