### PR TITLE
feat: implements a shared Columns shortcode

### DIFF
--- a/shortcodes/Columns/index.js
+++ b/shortcodes/Columns/index.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Renders a wrapper element around whatever is passed in and places each
+ * item into their own column.
+ * @param {string} content A string of markdown
+ */
+const Columns = content => {
+  // prettier-ignore
+  // The funky whitespace here is intentional.
+  // We need to have newlines between the ${content} so the markdown parser
+  // will kick in again.
+  // And because the content might be a <pre> element, which renders whitespace,
+  // we need to make sure it's not indented in any way.
+  return `<div class="columns">
+
+${content}
+
+</div>`;
+};
+
+const Column = content => {
+  return `<div class="columns__column">${content}</div>`;
+};
+
+module.exports = {Columns, Column};

--- a/shortcodes/Columns/styles.scss
+++ b/shortcodes/Columns/styles.scss
@@ -1,0 +1,10 @@
+.columns {
+  display: grid;
+  gap: get-size(300);
+  grid-auto-flow: row;
+
+  @include media-query('md') {
+    grid-auto-columns: 1fr;
+    grid-auto-flow: column;
+  }
+}

--- a/shortcodes/index.js
+++ b/shortcodes/index.js
@@ -4,6 +4,7 @@ module.exports = {
   ...require('./Details'),
   ...require('./DetailsSummary'),
   ...require('./IFrame'),
+  ...require('./Columns'),
   ...require('./Img'),
   ...require('./Video'),
   ...require('./YouTube'),


### PR DESCRIPTION
Resolves #57 

Since all the `w-column` in web.dev need to be removed, so It will be worth introducing the Columns shortcode we have on d.c.c to web.dev by moving this shortcode to webdev-infra. 


Changes in this pull request:

- Implements a shared Columns shortcode for both web.dev and d.c.c 

Usages:

```
{% Columns %}

{% Column %}
{% Img src="image/foR0vJZKULb5AGJExlazy1xYDgI2/iuwBXAyKJMz4b7oRyIdI.jpg", alt="ALT_TEXT_HERE", width="380", height="240" %}
Original
{% endColumn %}

{% Column %}
{% Img src="image/foR0vJZKULb5AGJExlazy1xYDgI2/iuwBXAyKJMz4b7oRyIdI.jpg", alt="ALT_TEXT_HERE", width="380", height="240", params={flip: 'h'} %}
Flipped
{% endColumn %}

{% endColumns %}
```