### PR TITLE
Compat widget label shape fixes

### DIFF
--- a/shortcodes/BrowserCompat/styles.scss
+++ b/shortcodes/BrowserCompat/styles.scss
@@ -57,13 +57,14 @@
 
   &__version {
     --size-2: clamp(0.75rem, 0.71rem + 0.18vw, 0.875rem); // From web.dev
-    border-radius: 100%;
+    border-radius: 1e4px;
     display: inline-block;
     font-size: var(--size-2);
     height: 20px;
     line-height: 20px;
     min-width: 20px;
     text-align: center;
+    padding-inline: .5ch;
   
     &[data-compat='yes'] {
       background: var(--wdi-success-bg-color, #e9f6ed);


### PR DESCRIPTION
before this PR:

![Screenshot 2023-03-17 at 9 04 39 AM](https://user-images.githubusercontent.com/1134620/225959534-f1731742-1a11-465d-8291-7206325d8220.png)

after this PR:

![Screenshot 2023-03-17 at 9 04 36 AM](https://user-images.githubusercontent.com/1134620/225959574-79be2526-3d40-41a5-856f-48486f68143f.png)
