### PR TITLE
Make browser name show up nicer in RSS

### DIFF
--- a/shortcodes/BrowserCompat/index.js
+++ b/shortcodes/BrowserCompat/index.js
@@ -108,6 +108,7 @@ function BrowserCompat(featureId) {
 
   const feature = DATA[featureId];
   shortcodeContext.browsers = BROWSERS.map(browser => {
+    const friendlyBrowserName = `${browser[0].toUpperCase()}${browser.slice(1)}`;
     let support = undefined;
     const status = undefined;
     if (feature && feature.support) {
@@ -123,13 +124,13 @@ function BrowserCompat(featureId) {
       : false;
 
     const ariaLabel = [
-      browser,
+      friendlyBrowserName,
       isSupported ? ` ${support.version_added}, ` : ', ',
       supportInfo.aria || '',
     ].join('');
 
     return {
-      name: browser,
+      name: friendlyBrowserName,
       supportInfo,
       ariaLabel,
       compat: supportInfo.compatProperty,

--- a/shortcodes/BrowserCompat/index.js
+++ b/shortcodes/BrowserCompat/index.js
@@ -25,7 +25,7 @@ const Nunjucks = require('nunjucks');
 const bcd = require('../../utils/browserCompat');
 const {i18n} = require('../../utils/i18nDictionary');
 
-const BROWSERS = ['chrome', 'firefox', 'edge', 'safari'];
+const BROWSERS = ['Chrome', 'Firefox', 'Edge', 'Safari'];
 const DATA = bcd();
 
 const TEMPLATE = new Nunjucks.Template(
@@ -108,7 +108,8 @@ function BrowserCompat(featureId) {
 
   const feature = DATA[featureId];
   shortcodeContext.browsers = BROWSERS.map(browser => {
-    const friendlyBrowserName = `${browser[0].toUpperCase()}${browser.slice(1)}`;
+    const friendlyBrowserName = browser;
+    browser = browser.toLowerCase();
     let support = undefined;
     const status = undefined;
     if (feature && feature.support) {


### PR DESCRIPTION
I hope this fixes the RSS feed issue highlighted below:

<img width="745" alt="Screenshot 2023-03-30 at 11 36 22" src="https://user-images.githubusercontent.com/145676/228812667-876d6e7f-543e-47c4-99eb-12add2651dd3.png">

The idea is to have a friendly name that reads `"Chrome"` instead of `"chrome"`. 