### PR TITLE
lint: fix prettier error

### DIFF
--- a/types/utils/feeds.d.ts
+++ b/types/utils/feeds.d.ts
@@ -29,7 +29,7 @@ type FeedsData = {
 
 export type AuthorFeedData = {
   [key: string]: FeedsData[];
-}
+};
 
 export type Feeds = {[key: string]: AuthorExternal[]};
 export type AuthorsFeedData = AuthorFeedData[];


### PR DESCRIPTION
Your bump version of the package failed because there is an error of the prettier lint.

```
1 problem (1 error, 0 warnings)
/Users/chaowaneejanthong/Tokyo/webdev-infra/types/utils/feeds.d.ts
32:2  error  Insert `;`  prettier/prettier
```

I have fixed it and checked that there is no more lint error.