### PR TITLE
Fix i18n directory not resolving properly when parentheses are used

### DIFF
--- a/utils/i18nDictionary.js
+++ b/utils/i18nDictionary.js
@@ -54,8 +54,6 @@ class I18nDictionary {
   loadEntries(dir) {
     const files = fg.sync(path.join(dir.replace(/([()])/g, '\\$1'), '/**/*.{yml,yaml}'));
 
-    console.log(files)
-
     const baseDir = path.dirname(dir);
     for (const file of files) {
       const dir = path.dirname(file);

--- a/utils/i18nDictionary.js
+++ b/utils/i18nDictionary.js
@@ -30,6 +30,7 @@ const get = require('lodash.get');
 const set = require('lodash.set');
 
 const DEFAULT_PATH = path.join(__dirname, '../data/i18n');
+const ESCAPE_PARENTHESES_PATTERN = /([()])/g;
 
 class I18nDictionary {
   constructor(defaultPath = DEFAULT_PATH) {
@@ -52,7 +53,10 @@ class I18nDictionary {
    * @param {string} dir The directory to walk
    */
   loadEntries(dir) {
-    const files = fg.sync(path.join(dir.replace(/([()])/g, '\\$1'), '/**/*.{yml,yaml}'));
+    // Replace any parentheses in the directory path with escaped versions of themselves
+    // This is necessary because fast-glob has problems parsing folders containing parentheses.
+    const cleanDir = dir.replace(ESCAPE_PARENTHESES_PATTERN, '\\$1');
+    const files = fg.sync(path.join(cleanDir, '/**/*.{yml,yaml}'));
 
     const baseDir = path.dirname(dir);
     for (const file of files) {

--- a/utils/i18nDictionary.js
+++ b/utils/i18nDictionary.js
@@ -52,7 +52,9 @@ class I18nDictionary {
    * @param {string} dir The directory to walk
    */
   loadEntries(dir) {
-    const files = fg.sync(path.join(dir, '/**/*.{yml,yaml}'));
+    const files = fg.sync(path.join(dir.replace(/([()])/g, '\\$1'), '/**/*.{yml,yaml}'));
+
+    console.log(files)
 
     const baseDir = path.dirname(dir);
     for (const file of files) {


### PR DESCRIPTION
Fixes #66

It would appear that the issue does not relate to the use of spaces, but rather special characters. This also seems to only effect parentheses, and no other special characters as tested (tested with the following: <> [] {} -- == ** ^^).

## How to test
1. Clone webdev-infra and checkout this branch '77_i18n_util_fails_if_run_from_path_with_spaces'
2. Create a local folder which contains parentheses in (e.g. /Shay/programming/Shay (test)/)
3. Clone developer.chrome.com or web.dev to the folder
4. Setup a symlink to the appropriate place
5. run 'npm ci'
6. run 'npm run dev'
7. successful build should happen