### PR TITLE
Feat: added fallback text option to youtube embed

### DIFF
--- a/shortcodes/YouTube.js
+++ b/shortcodes/YouTube.js
@@ -44,13 +44,14 @@ function YouTube(...options) {
   }
 
   return html`
-    <div class="youtube">
-      <lite-youtube
-        videoid="${id}"
-        ${startTime ? `videoStartAt="${startTime}"` : ''}
-      >
-      </lite-youtube>
-    </div>
+      <div class="youtube">
+        <lite-youtube
+          videoid="${id}"
+          ${startTime ? `videoStartAt="${startTime}"` : ''}
+        >
+          <a class="youtube-fallback" href="https://www.youtube.com/watch?v=${id}">Watch on YouTube</a>
+        </lite-youtube>
+      </div>
   `.replace(/\n/g, '');
 }
 


### PR DESCRIPTION
Fixes: [#6193](https://github.com/GoogleChrome/developer.chrome.com/issues/6193)

Suggested changes:
- Adds fallback text to lite-youtube

How to test:
1. Clone webdev-infra and checkout branch 
2. Clone d.c.c repository and checkout branch `6193_youtube_embed_should_show_fallback_link_when_js_is_disabled`
3. Setup a sym link between the webdev-infra and d.c.c repository
4. Navigate to /blog/new-in-chrome-113/ with javascript enabled, you should see the youtube video as expected
5. Disable javascript
6. Refresh the page, you should now see the fallback text in place of the youtube video